### PR TITLE
Document type choice page

### DIFF
--- a/cypress/e2e/document_type_page.cy.js
+++ b/cypress/e2e/document_type_page.cy.js
@@ -1,0 +1,32 @@
+describe('testing the start page loads', () => {
+    it('can load a webpage', () => {
+      cy.visit('http://localhost:3000/document-type')
+    })
+  
+    it("should have a title",()=>{
+      cy.title().should('eq','Document Type')
+    })
+  
+    it("it should have a heading", () => {
+      cy.get('#hd-doc-type').contains('Document Type')
+      cy.get('#hd-doc-type').should('have.class', 'govuk-heading-xl')
+    })
+  })
+  
+  describe('page contents', () => {
+    it('has a dropdown menu', () => {
+        cy.get('#sort-doc-type').should('have.class', 'govuk-select')
+        cy.get('#sort-doc-type').should('have.class', 'govuk-select')
+        cy.get('#sort-doc-type').select('licence')
+    })
+
+    it('has a continue button', () => {
+        cy.get('#btn-doc-type-continue').should('have.class', 'govuk-button')
+        cy.get('#btn-doc-type-continue').contains('Continue to upload')
+    })
+
+    it("takes you to /upload-rules", () => {
+        cy.get('#btn-doc-type-continue').click()
+        cy.url().should('include', '/upload-rules')
+      })
+})

--- a/src/pages/document_type.html
+++ b/src/pages/document_type.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>GOV.UK - The best place to find government services and information</title>
+  <title>Document Type</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 
@@ -63,7 +63,27 @@
 
   <div class="govuk-width-container ">
     <main class="govuk-main-wrapper " id="main-content" role="main">
-      <h1 class="govuk-heading-xl">Default page template</h1>
+      <h1 class="govuk-heading-xl" id="hd-doc-type">Document Type</h1>
+
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="sort">
+          Choose which document you would like to upload
+        </label>
+        <select class="govuk-select" id="sort-doc-type" name="sort">
+          <option value="passport" selected>Passport</option>
+          <option value="licence">Driving licence</option>
+          <option value="address">Proof of address</option>
+        </select>
+      </div>
+
+      <div class="govuk-button-group">
+        <a href="/upload-rules">
+        <button id="btn-doc-type-continue" class="govuk-button" data-module="govuk-button">
+          Continue to upload
+        </button>
+        </a>
+      </div>
+
     </main>
   </div>
 


### PR DESCRIPTION
Built the document type choice page - we may need to discuss the use of a dropdown menu going forward as it looks like GDS only suggests using them as a last resort.

The continue to upload button is linked up and navigates to the next page as well